### PR TITLE
Fix BigDecimal deprecations when running on Ruby 2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
 gemspec
-gem 'rspec'

--- a/Rakefile
+++ b/Rakefile
@@ -71,7 +71,7 @@ def generate_tests specs
   }.each {|money_string, result, comment|
 
       expecting = if result
-        "BigDecimal.new(\"#{result.inspect}\")"
+        "BigDecimal(\"#{result.inspect}\")"
       else
         result.inspect
       end

--- a/lib/money_parser.rb
+++ b/lib/money_parser.rb
@@ -37,7 +37,7 @@ module MoneyParser
       end
     end
 
-    normalized ? BigDecimal.new(normalized) : normalized
+    normalized ? BigDecimal(normalized) : normalized
   end
 
 end

--- a/spec/money_parser_spec.rb
+++ b/spec/money_parser_spec.rb
@@ -108,1587 +108,1587 @@ describe MoneyParser do
 
 
   it '"2000.01" should be parsed as 2000.01 ' do
-    MoneyParser.parse("2000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("2000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"-2000.01" should be parsed as -2000.01 (negative amount)' do
-    MoneyParser.parse("-2000.01").should == BigDecimal.new("-2000.01")
+    MoneyParser.parse("-2000.01").should == BigDecimal("-2000.01")
   end
 
 
   it '"20o0.01" should be parsed as 2000.01 (with O instead of 0)' do
-    MoneyParser.parse("20o0.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("20o0.01").should == BigDecimal("2000.01")
   end
 
 
   it '"$2000.01" should be parsed as 2000.01 (with a dollar sign)' do
-    MoneyParser.parse("$2000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("$2000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"€2000.01" should be parsed as 2000.01 (with a euro sign)' do
-    MoneyParser.parse("€2000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("€2000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"£2000.01" should be parsed as 2000.01 (with a pound sign)' do
-    MoneyParser.parse("£2000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("£2000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"₤2000.01" should be parsed as 2000.01 (with a pound sign)' do
-    MoneyParser.parse("₤2000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("₤2000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"2000,01" should be parsed as 2000.01 ' do
-    MoneyParser.parse("2000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("2000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"-2000,01" should be parsed as -2000.01 (negative amount)' do
-    MoneyParser.parse("-2000,01").should == BigDecimal.new("-2000.01")
+    MoneyParser.parse("-2000,01").should == BigDecimal("-2000.01")
   end
 
 
   it '"2000,o1" should be parsed as 2000.01 (with O instead of 0)' do
-    MoneyParser.parse("2000,o1").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("2000,o1").should == BigDecimal("2000.01")
   end
 
 
   it '"$2000,01" should be parsed as 2000.01 (with a dollar sign)' do
-    MoneyParser.parse("$2000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("$2000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"€2000,01" should be parsed as 2000.01 (with a euro sign)' do
-    MoneyParser.parse("€2000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("€2000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"£2000,01" should be parsed as 2000.01 (with a pound sign)' do
-    MoneyParser.parse("£2000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("£2000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"₤2000,01" should be parsed as 2000.01 (with a pound sign)' do
-    MoneyParser.parse("₤2000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("₤2000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"2000.1" should be parsed as 2000.1 ' do
-    MoneyParser.parse("2000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2000.1").should == BigDecimal("2000.1")
   end
 
 
   it '"-2000.1" should be parsed as -2000.1 (negative amount)' do
-    MoneyParser.parse("-2000.1").should == BigDecimal.new("-2000.1")
+    MoneyParser.parse("-2000.1").should == BigDecimal("-2000.1")
   end
 
 
   it '"20o0.1" should be parsed as 2000.1 (with O instead of 0)' do
-    MoneyParser.parse("20o0.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("20o0.1").should == BigDecimal("2000.1")
   end
 
 
   it '"$2000.1" should be parsed as 2000.1 (with a dollar sign)' do
-    MoneyParser.parse("$2000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("$2000.1").should == BigDecimal("2000.1")
   end
 
 
   it '"€2000.1" should be parsed as 2000.1 (with a euro sign)' do
-    MoneyParser.parse("€2000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("€2000.1").should == BigDecimal("2000.1")
   end
 
 
   it '"£2000.1" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("£2000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("£2000.1").should == BigDecimal("2000.1")
   end
 
 
   it '"₤2000.1" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("₤2000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("₤2000.1").should == BigDecimal("2000.1")
   end
 
 
   it '"2000,1" should be parsed as 2000.1 ' do
-    MoneyParser.parse("2000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2000,1").should == BigDecimal("2000.1")
   end
 
 
   it '" -2000,1" should be parsed as -2000.1 (negative amount)' do
-    MoneyParser.parse(" -2000,1").should == BigDecimal.new("-2000.1")
+    MoneyParser.parse(" -2000,1").should == BigDecimal("-2000.1")
   end
 
 
   it '"2o00,1" should be parsed as 2000.1 (with O instead of 0)' do
-    MoneyParser.parse("2o00,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2o00,1").should == BigDecimal("2000.1")
   end
 
 
   it '"$2000,1" should be parsed as 2000.1 (with a dollar sign)' do
-    MoneyParser.parse("$2000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("$2000,1").should == BigDecimal("2000.1")
   end
 
 
   it '"€2000,1" should be parsed as 2000.1 (with a euro sign)' do
-    MoneyParser.parse("€2000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("€2000,1").should == BigDecimal("2000.1")
   end
 
 
   it '"£2000,1" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("£2000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("£2000,1").should == BigDecimal("2000.1")
   end
 
 
   it '"₤2000,1" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("₤2000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("₤2000,1").should == BigDecimal("2000.1")
   end
 
 
   it '"2000" should be parsed as 2000.0 ' do
-    MoneyParser.parse("2000").should == BigDecimal.new("2000.0")
+    MoneyParser.parse("2000").should == BigDecimal("2000.0")
   end
 
 
   it '" - 2000" should be parsed as -2000.0 (negative amount)' do
-    MoneyParser.parse(" - 2000").should == BigDecimal.new("-2000.0")
+    MoneyParser.parse(" - 2000").should == BigDecimal("-2000.0")
   end
 
 
   it '"2o00" should be parsed as 2000.0 (with O instead of 0)' do
-    MoneyParser.parse("2o00").should == BigDecimal.new("2000.0")
+    MoneyParser.parse("2o00").should == BigDecimal("2000.0")
   end
 
 
   it '"$2000" should be parsed as 2000.0 (with a dollar sign)' do
-    MoneyParser.parse("$2000").should == BigDecimal.new("2000.0")
+    MoneyParser.parse("$2000").should == BigDecimal("2000.0")
   end
 
 
   it '"€2000" should be parsed as 2000.0 (with a euro sign)' do
-    MoneyParser.parse("€2000").should == BigDecimal.new("2000.0")
+    MoneyParser.parse("€2000").should == BigDecimal("2000.0")
   end
 
 
   it '"£2000" should be parsed as 2000.0 (with a pound sign)' do
-    MoneyParser.parse("£2000").should == BigDecimal.new("2000.0")
+    MoneyParser.parse("£2000").should == BigDecimal("2000.0")
   end
 
 
   it '"₤2000" should be parsed as 2000.0 (with a pound sign)' do
-    MoneyParser.parse("₤2000").should == BigDecimal.new("2000.0")
+    MoneyParser.parse("₤2000").should == BigDecimal("2000.0")
   end
 
 
   it '".01" should be parsed as 0.01 ' do
-    MoneyParser.parse(".01").should == BigDecimal.new("0.01")
+    MoneyParser.parse(".01").should == BigDecimal("0.01")
   end
 
 
   it '"-.01" should be parsed as -0.01 (negative amount)' do
-    MoneyParser.parse("-.01").should == BigDecimal.new("-0.01")
+    MoneyParser.parse("-.01").should == BigDecimal("-0.01")
   end
 
 
   it '".o1" should be parsed as 0.01 (with O instead of 0)' do
-    MoneyParser.parse(".o1").should == BigDecimal.new("0.01")
+    MoneyParser.parse(".o1").should == BigDecimal("0.01")
   end
 
 
   it '"$.01" should be parsed as 0.01 (with a dollar sign)' do
-    MoneyParser.parse("$.01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("$.01").should == BigDecimal("0.01")
   end
 
 
   it '"€.01" should be parsed as 0.01 (with a euro sign)' do
-    MoneyParser.parse("€.01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("€.01").should == BigDecimal("0.01")
   end
 
 
   it '"£.01" should be parsed as 0.01 (with a pound sign)' do
-    MoneyParser.parse("£.01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("£.01").should == BigDecimal("0.01")
   end
 
 
   it '"₤.01" should be parsed as 0.01 (with a pound sign)' do
-    MoneyParser.parse("₤.01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("₤.01").should == BigDecimal("0.01")
   end
 
 
   it '",01" should be parsed as 0.01 ' do
-    MoneyParser.parse(",01").should == BigDecimal.new("0.01")
+    MoneyParser.parse(",01").should == BigDecimal("0.01")
   end
 
 
   it '" -,01" should be parsed as -0.01 (negative amount)' do
-    MoneyParser.parse(" -,01").should == BigDecimal.new("-0.01")
+    MoneyParser.parse(" -,01").should == BigDecimal("-0.01")
   end
 
 
   it '",o1" should be parsed as 0.01 (with O instead of 0)' do
-    MoneyParser.parse(",o1").should == BigDecimal.new("0.01")
+    MoneyParser.parse(",o1").should == BigDecimal("0.01")
   end
 
 
   it '"$,01" should be parsed as 0.01 (with a dollar sign)' do
-    MoneyParser.parse("$,01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("$,01").should == BigDecimal("0.01")
   end
 
 
   it '"€,01" should be parsed as 0.01 (with a euro sign)' do
-    MoneyParser.parse("€,01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("€,01").should == BigDecimal("0.01")
   end
 
 
   it '"£,01" should be parsed as 0.01 (with a pound sign)' do
-    MoneyParser.parse("£,01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("£,01").should == BigDecimal("0.01")
   end
 
 
   it '"₤,01" should be parsed as 0.01 (with a pound sign)' do
-    MoneyParser.parse("₤,01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("₤,01").should == BigDecimal("0.01")
   end
 
 
   it '"0.01" should be parsed as 0.01 ' do
-    MoneyParser.parse("0.01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("0.01").should == BigDecimal("0.01")
   end
 
 
   it '" -0.01" should be parsed as -0.01 (negative amount)' do
-    MoneyParser.parse(" -0.01").should == BigDecimal.new("-0.01")
+    MoneyParser.parse(" -0.01").should == BigDecimal("-0.01")
   end
 
 
   it '"o.01" should be parsed as 0.01 (with O instead of 0)' do
-    MoneyParser.parse("o.01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("o.01").should == BigDecimal("0.01")
   end
 
 
   it '"$0.01" should be parsed as 0.01 (with a dollar sign)' do
-    MoneyParser.parse("$0.01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("$0.01").should == BigDecimal("0.01")
   end
 
 
   it '"€0.01" should be parsed as 0.01 (with a euro sign)' do
-    MoneyParser.parse("€0.01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("€0.01").should == BigDecimal("0.01")
   end
 
 
   it '"£0.01" should be parsed as 0.01 (with a pound sign)' do
-    MoneyParser.parse("£0.01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("£0.01").should == BigDecimal("0.01")
   end
 
 
   it '"₤0.01" should be parsed as 0.01 (with a pound sign)' do
-    MoneyParser.parse("₤0.01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("₤0.01").should == BigDecimal("0.01")
   end
 
 
   it '"0,01" should be parsed as 0.01 ' do
-    MoneyParser.parse("0,01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("0,01").should == BigDecimal("0.01")
   end
 
 
   it '" - 0,01" should be parsed as -0.01 (negative amount)' do
-    MoneyParser.parse(" - 0,01").should == BigDecimal.new("-0.01")
+    MoneyParser.parse(" - 0,01").should == BigDecimal("-0.01")
   end
 
 
   it '"o,01" should be parsed as 0.01 (with O instead of 0)' do
-    MoneyParser.parse("o,01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("o,01").should == BigDecimal("0.01")
   end
 
 
   it '"$0,01" should be parsed as 0.01 (with a dollar sign)' do
-    MoneyParser.parse("$0,01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("$0,01").should == BigDecimal("0.01")
   end
 
 
   it '"€0,01" should be parsed as 0.01 (with a euro sign)' do
-    MoneyParser.parse("€0,01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("€0,01").should == BigDecimal("0.01")
   end
 
 
   it '"£0,01" should be parsed as 0.01 (with a pound sign)' do
-    MoneyParser.parse("£0,01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("£0,01").should == BigDecimal("0.01")
   end
 
 
   it '"₤0,01" should be parsed as 0.01 (with a pound sign)' do
-    MoneyParser.parse("₤0,01").should == BigDecimal.new("0.01")
+    MoneyParser.parse("₤0,01").should == BigDecimal("0.01")
   end
 
 
   it '".1" should be parsed as 0.1 ' do
-    MoneyParser.parse(".1").should == BigDecimal.new("0.1")
+    MoneyParser.parse(".1").should == BigDecimal("0.1")
   end
 
 
   it '" - .1" should be parsed as -0.1 (negative amount)' do
-    MoneyParser.parse(" - .1").should == BigDecimal.new("-0.1")
+    MoneyParser.parse(" - .1").should == BigDecimal("-0.1")
   end
 
 
   it '"$.1" should be parsed as 0.1 (with a dollar sign)' do
-    MoneyParser.parse("$.1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("$.1").should == BigDecimal("0.1")
   end
 
 
   it '"€.1" should be parsed as 0.1 (with a euro sign)' do
-    MoneyParser.parse("€.1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("€.1").should == BigDecimal("0.1")
   end
 
 
   it '"£.1" should be parsed as 0.1 (with a pound sign)' do
-    MoneyParser.parse("£.1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("£.1").should == BigDecimal("0.1")
   end
 
 
   it '"₤.1" should be parsed as 0.1 (with a pound sign)' do
-    MoneyParser.parse("₤.1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("₤.1").should == BigDecimal("0.1")
   end
 
 
   it '",1" should be parsed as 0.1 ' do
-    MoneyParser.parse(",1").should == BigDecimal.new("0.1")
+    MoneyParser.parse(",1").should == BigDecimal("0.1")
   end
 
 
   it '"- ,1" should be parsed as -0.1 (negative amount)' do
-    MoneyParser.parse("- ,1").should == BigDecimal.new("-0.1")
+    MoneyParser.parse("- ,1").should == BigDecimal("-0.1")
   end
 
 
   it '"$,1" should be parsed as 0.1 (with a dollar sign)' do
-    MoneyParser.parse("$,1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("$,1").should == BigDecimal("0.1")
   end
 
 
   it '"€,1" should be parsed as 0.1 (with a euro sign)' do
-    MoneyParser.parse("€,1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("€,1").should == BigDecimal("0.1")
   end
 
 
   it '"£,1" should be parsed as 0.1 (with a pound sign)' do
-    MoneyParser.parse("£,1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("£,1").should == BigDecimal("0.1")
   end
 
 
   it '"₤,1" should be parsed as 0.1 (with a pound sign)' do
-    MoneyParser.parse("₤,1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("₤,1").should == BigDecimal("0.1")
   end
 
 
   it '"0.1" should be parsed as 0.1 ' do
-    MoneyParser.parse("0.1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("0.1").should == BigDecimal("0.1")
   end
 
 
   it '" - 0.1" should be parsed as -0.1 (negative amount)' do
-    MoneyParser.parse(" - 0.1").should == BigDecimal.new("-0.1")
+    MoneyParser.parse(" - 0.1").should == BigDecimal("-0.1")
   end
 
 
   it '"o.1" should be parsed as 0.1 (with O instead of 0)' do
-    MoneyParser.parse("o.1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("o.1").should == BigDecimal("0.1")
   end
 
 
   it '"$0.1" should be parsed as 0.1 (with a dollar sign)' do
-    MoneyParser.parse("$0.1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("$0.1").should == BigDecimal("0.1")
   end
 
 
   it '"€0.1" should be parsed as 0.1 (with a euro sign)' do
-    MoneyParser.parse("€0.1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("€0.1").should == BigDecimal("0.1")
   end
 
 
   it '"£0.1" should be parsed as 0.1 (with a pound sign)' do
-    MoneyParser.parse("£0.1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("£0.1").should == BigDecimal("0.1")
   end
 
 
   it '"₤0.1" should be parsed as 0.1 (with a pound sign)' do
-    MoneyParser.parse("₤0.1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("₤0.1").should == BigDecimal("0.1")
   end
 
 
   it '"0,1" should be parsed as 0.1 ' do
-    MoneyParser.parse("0,1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("0,1").should == BigDecimal("0.1")
   end
 
 
   it '"- 0,1" should be parsed as -0.1 (negative amount)' do
-    MoneyParser.parse("- 0,1").should == BigDecimal.new("-0.1")
+    MoneyParser.parse("- 0,1").should == BigDecimal("-0.1")
   end
 
 
   it '"o,1" should be parsed as 0.1 (with O instead of 0)' do
-    MoneyParser.parse("o,1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("o,1").should == BigDecimal("0.1")
   end
 
 
   it '"$0,1" should be parsed as 0.1 (with a dollar sign)' do
-    MoneyParser.parse("$0,1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("$0,1").should == BigDecimal("0.1")
   end
 
 
   it '"€0,1" should be parsed as 0.1 (with a euro sign)' do
-    MoneyParser.parse("€0,1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("€0,1").should == BigDecimal("0.1")
   end
 
 
   it '"£0,1" should be parsed as 0.1 (with a pound sign)' do
-    MoneyParser.parse("£0,1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("£0,1").should == BigDecimal("0.1")
   end
 
 
   it '"₤0,1" should be parsed as 0.1 (with a pound sign)' do
-    MoneyParser.parse("₤0,1").should == BigDecimal.new("0.1")
+    MoneyParser.parse("₤0,1").should == BigDecimal("0.1")
   end
 
 
   it '"2,000.01" should be parsed as 2000.01 ' do
-    MoneyParser.parse("2,000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("2,000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"-2,000.01" should be parsed as -2000.01 (negative amount)' do
-    MoneyParser.parse("-2,000.01").should == BigDecimal.new("-2000.01")
+    MoneyParser.parse("-2,000.01").should == BigDecimal("-2000.01")
   end
 
 
   it '"2,0o0.01" should be parsed as 2000.01 (with O instead of 0)' do
-    MoneyParser.parse("2,0o0.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("2,0o0.01").should == BigDecimal("2000.01")
   end
 
 
   it '"$2,000.01" should be parsed as 2000.01 (with a dollar sign)' do
-    MoneyParser.parse("$2,000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("$2,000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"€2,000.01" should be parsed as 2000.01 (with a euro sign)' do
-    MoneyParser.parse("€2,000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("€2,000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"£2,000.01" should be parsed as 2000.01 (with a pound sign)' do
-    MoneyParser.parse("£2,000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("£2,000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"₤2,000.01" should be parsed as 2000.01 (with a pound sign)' do
-    MoneyParser.parse("₤2,000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("₤2,000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"2.000,01" should be parsed as 2000.01 ' do
-    MoneyParser.parse("2.000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("2.000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"-2.000,01" should be parsed as -2000.01 (negative amount)' do
-    MoneyParser.parse("-2.000,01").should == BigDecimal.new("-2000.01")
+    MoneyParser.parse("-2.000,01").should == BigDecimal("-2000.01")
   end
 
 
   it '"2.o00,01" should be parsed as 2000.01 (with O instead of 0)' do
-    MoneyParser.parse("2.o00,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("2.o00,01").should == BigDecimal("2000.01")
   end
 
 
   it '"$2.000,01" should be parsed as 2000.01 (with a dollar sign)' do
-    MoneyParser.parse("$2.000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("$2.000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"€2.000,01" should be parsed as 2000.01 (with a euro sign)' do
-    MoneyParser.parse("€2.000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("€2.000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"£2.000,01" should be parsed as 2000.01 (with a pound sign)' do
-    MoneyParser.parse("£2.000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("£2.000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"₤2.000,01" should be parsed as 2000.01 (with a pound sign)' do
-    MoneyParser.parse("₤2.000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("₤2.000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"2 000.01" should be parsed as 2000.01 ' do
-    MoneyParser.parse("2 000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("2 000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"- 2 000.01" should be parsed as -2000.01 (negative amount)' do
-    MoneyParser.parse("- 2 000.01").should == BigDecimal.new("-2000.01")
+    MoneyParser.parse("- 2 000.01").should == BigDecimal("-2000.01")
   end
 
 
   it '"2 000.o1" should be parsed as 2000.01 (with O instead of 0)' do
-    MoneyParser.parse("2 000.o1").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("2 000.o1").should == BigDecimal("2000.01")
   end
 
 
   it '"$2 000.01" should be parsed as 2000.01 (with a dollar sign)' do
-    MoneyParser.parse("$2 000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("$2 000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"€2 000.01" should be parsed as 2000.01 (with a euro sign)' do
-    MoneyParser.parse("€2 000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("€2 000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"£2 000.01" should be parsed as 2000.01 (with a pound sign)' do
-    MoneyParser.parse("£2 000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("£2 000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"₤2 000.01" should be parsed as 2000.01 (with a pound sign)' do
-    MoneyParser.parse("₤2 000.01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("₤2 000.01").should == BigDecimal("2000.01")
   end
 
 
   it '"2 000,01" should be parsed as 2000.01 ' do
-    MoneyParser.parse("2 000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("2 000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"- 2 000,01" should be parsed as -2000.01 (negative amount)' do
-    MoneyParser.parse("- 2 000,01").should == BigDecimal.new("-2000.01")
+    MoneyParser.parse("- 2 000,01").should == BigDecimal("-2000.01")
   end
 
 
   it '"2 000,o1" should be parsed as 2000.01 (with O instead of 0)' do
-    MoneyParser.parse("2 000,o1").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("2 000,o1").should == BigDecimal("2000.01")
   end
 
 
   it '"$2 000,01" should be parsed as 2000.01 (with a dollar sign)' do
-    MoneyParser.parse("$2 000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("$2 000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"€2 000,01" should be parsed as 2000.01 (with a euro sign)' do
-    MoneyParser.parse("€2 000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("€2 000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"£2 000,01" should be parsed as 2000.01 (with a pound sign)' do
-    MoneyParser.parse("£2 000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("£2 000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"₤2 000,01" should be parsed as 2000.01 (with a pound sign)' do
-    MoneyParser.parse("₤2 000,01").should == BigDecimal.new("2000.01")
+    MoneyParser.parse("₤2 000,01").should == BigDecimal("2000.01")
   end
 
 
   it '"1,222,000.01" should be parsed as 1222000.01 ' do
-    MoneyParser.parse("1,222,000.01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("1,222,000.01").should == BigDecimal("1222000.01")
   end
 
 
   it '"-1,222,000.01" should be parsed as -1222000.01 (negative amount)' do
-    MoneyParser.parse("-1,222,000.01").should == BigDecimal.new("-1222000.01")
+    MoneyParser.parse("-1,222,000.01").should == BigDecimal("-1222000.01")
   end
 
 
   it '"1,222,o00.01" should be parsed as 1222000.01 (with O instead of 0)' do
-    MoneyParser.parse("1,222,o00.01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("1,222,o00.01").should == BigDecimal("1222000.01")
   end
 
 
   it '"$1,222,000.01" should be parsed as 1222000.01 (with a dollar sign)' do
-    MoneyParser.parse("$1,222,000.01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("$1,222,000.01").should == BigDecimal("1222000.01")
   end
 
 
   it '"€1,222,000.01" should be parsed as 1222000.01 (with a euro sign)' do
-    MoneyParser.parse("€1,222,000.01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("€1,222,000.01").should == BigDecimal("1222000.01")
   end
 
 
   it '"£1,222,000.01" should be parsed as 1222000.01 (with a pound sign)' do
-    MoneyParser.parse("£1,222,000.01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("£1,222,000.01").should == BigDecimal("1222000.01")
   end
 
 
   it '"₤1,222,000.01" should be parsed as 1222000.01 (with a pound sign)' do
-    MoneyParser.parse("₤1,222,000.01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("₤1,222,000.01").should == BigDecimal("1222000.01")
   end
 
 
   it '"1.222.000,01" should be parsed as 1222000.01 ' do
-    MoneyParser.parse("1.222.000,01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("1.222.000,01").should == BigDecimal("1222000.01")
   end
 
 
   it '"-1.222.000,01" should be parsed as -1222000.01 (negative amount)' do
-    MoneyParser.parse("-1.222.000,01").should == BigDecimal.new("-1222000.01")
+    MoneyParser.parse("-1.222.000,01").should == BigDecimal("-1222000.01")
   end
 
 
   it '"1.222.0o0,01" should be parsed as 1222000.01 (with O instead of 0)' do
-    MoneyParser.parse("1.222.0o0,01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("1.222.0o0,01").should == BigDecimal("1222000.01")
   end
 
 
   it '"$1.222.000,01" should be parsed as 1222000.01 (with a dollar sign)' do
-    MoneyParser.parse("$1.222.000,01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("$1.222.000,01").should == BigDecimal("1222000.01")
   end
 
 
   it '"€1.222.000,01" should be parsed as 1222000.01 (with a euro sign)' do
-    MoneyParser.parse("€1.222.000,01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("€1.222.000,01").should == BigDecimal("1222000.01")
   end
 
 
   it '"£1.222.000,01" should be parsed as 1222000.01 (with a pound sign)' do
-    MoneyParser.parse("£1.222.000,01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("£1.222.000,01").should == BigDecimal("1222000.01")
   end
 
 
   it '"₤1.222.000,01" should be parsed as 1222000.01 (with a pound sign)' do
-    MoneyParser.parse("₤1.222.000,01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("₤1.222.000,01").should == BigDecimal("1222000.01")
   end
 
 
   it '"1 222 000.01" should be parsed as 1222000.01 ' do
-    MoneyParser.parse("1 222 000.01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("1 222 000.01").should == BigDecimal("1222000.01")
   end
 
 
   it '" -1 222 000.01" should be parsed as -1222000.01 (negative amount)' do
-    MoneyParser.parse(" -1 222 000.01").should == BigDecimal.new("-1222000.01")
+    MoneyParser.parse(" -1 222 000.01").should == BigDecimal("-1222000.01")
   end
 
 
   it '"1 222 0o0.01" should be parsed as 1222000.01 (with O instead of 0)' do
-    MoneyParser.parse("1 222 0o0.01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("1 222 0o0.01").should == BigDecimal("1222000.01")
   end
 
 
   it '"$1 222 000.01" should be parsed as 1222000.01 (with a dollar sign)' do
-    MoneyParser.parse("$1 222 000.01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("$1 222 000.01").should == BigDecimal("1222000.01")
   end
 
 
   it '"€1 222 000.01" should be parsed as 1222000.01 (with a euro sign)' do
-    MoneyParser.parse("€1 222 000.01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("€1 222 000.01").should == BigDecimal("1222000.01")
   end
 
 
   it '"£1 222 000.01" should be parsed as 1222000.01 (with a pound sign)' do
-    MoneyParser.parse("£1 222 000.01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("£1 222 000.01").should == BigDecimal("1222000.01")
   end
 
 
   it '"₤1 222 000.01" should be parsed as 1222000.01 (with a pound sign)' do
-    MoneyParser.parse("₤1 222 000.01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("₤1 222 000.01").should == BigDecimal("1222000.01")
   end
 
 
   it '"1 222 000,01" should be parsed as 1222000.01 ' do
-    MoneyParser.parse("1 222 000,01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("1 222 000,01").should == BigDecimal("1222000.01")
   end
 
 
   it '" - 1 222 000,01" should be parsed as -1222000.01 (negative amount)' do
-    MoneyParser.parse(" - 1 222 000,01").should == BigDecimal.new("-1222000.01")
+    MoneyParser.parse(" - 1 222 000,01").should == BigDecimal("-1222000.01")
   end
 
 
   it '"1 222 0o0,01" should be parsed as 1222000.01 (with O instead of 0)' do
-    MoneyParser.parse("1 222 0o0,01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("1 222 0o0,01").should == BigDecimal("1222000.01")
   end
 
 
   it '"$1 222 000,01" should be parsed as 1222000.01 (with a dollar sign)' do
-    MoneyParser.parse("$1 222 000,01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("$1 222 000,01").should == BigDecimal("1222000.01")
   end
 
 
   it '"€1 222 000,01" should be parsed as 1222000.01 (with a euro sign)' do
-    MoneyParser.parse("€1 222 000,01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("€1 222 000,01").should == BigDecimal("1222000.01")
   end
 
 
   it '"£1 222 000,01" should be parsed as 1222000.01 (with a pound sign)' do
-    MoneyParser.parse("£1 222 000,01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("£1 222 000,01").should == BigDecimal("1222000.01")
   end
 
 
   it '"₤1 222 000,01" should be parsed as 1222000.01 (with a pound sign)' do
-    MoneyParser.parse("₤1 222 000,01").should == BigDecimal.new("1222000.01")
+    MoneyParser.parse("₤1 222 000,01").should == BigDecimal("1222000.01")
   end
 
 
   it '"2,000.1" should be parsed as 2000.1 ' do
-    MoneyParser.parse("2,000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2,000.1").should == BigDecimal("2000.1")
   end
 
 
   it '"- 2,000.1" should be parsed as -2000.1 (negative amount)' do
-    MoneyParser.parse("- 2,000.1").should == BigDecimal.new("-2000.1")
+    MoneyParser.parse("- 2,000.1").should == BigDecimal("-2000.1")
   end
 
 
   it '"2,0o0.1" should be parsed as 2000.1 (with O instead of 0)' do
-    MoneyParser.parse("2,0o0.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2,0o0.1").should == BigDecimal("2000.1")
   end
 
 
   it '"$2,000.1" should be parsed as 2000.1 (with a dollar sign)' do
-    MoneyParser.parse("$2,000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("$2,000.1").should == BigDecimal("2000.1")
   end
 
 
   it '"€2,000.1" should be parsed as 2000.1 (with a euro sign)' do
-    MoneyParser.parse("€2,000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("€2,000.1").should == BigDecimal("2000.1")
   end
 
 
   it '"£2,000.1" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("£2,000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("£2,000.1").should == BigDecimal("2000.1")
   end
 
 
   it '"₤2,000.1" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("₤2,000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("₤2,000.1").should == BigDecimal("2000.1")
   end
 
 
   it '"2.000,1" should be parsed as 2000.1 ' do
-    MoneyParser.parse("2.000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2.000,1").should == BigDecimal("2000.1")
   end
 
 
   it '" -2.000,1" should be parsed as -2000.1 (negative amount)' do
-    MoneyParser.parse(" -2.000,1").should == BigDecimal.new("-2000.1")
+    MoneyParser.parse(" -2.000,1").should == BigDecimal("-2000.1")
   end
 
 
   it '"2.00o,1" should be parsed as 2000.1 (with O instead of 0)' do
-    MoneyParser.parse("2.00o,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2.00o,1").should == BigDecimal("2000.1")
   end
 
 
   it '"$2.000,1" should be parsed as 2000.1 (with a dollar sign)' do
-    MoneyParser.parse("$2.000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("$2.000,1").should == BigDecimal("2000.1")
   end
 
 
   it '"€2.000,1" should be parsed as 2000.1 (with a euro sign)' do
-    MoneyParser.parse("€2.000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("€2.000,1").should == BigDecimal("2000.1")
   end
 
 
   it '"£2.000,1" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("£2.000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("£2.000,1").should == BigDecimal("2000.1")
   end
 
 
   it '"₤2.000,1" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("₤2.000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("₤2.000,1").should == BigDecimal("2000.1")
   end
 
 
   it '"2 000.1" should be parsed as 2000.1 ' do
-    MoneyParser.parse("2 000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2 000.1").should == BigDecimal("2000.1")
   end
 
 
   it '" -2 000.1" should be parsed as -2000.1 (negative amount)' do
-    MoneyParser.parse(" -2 000.1").should == BigDecimal.new("-2000.1")
+    MoneyParser.parse(" -2 000.1").should == BigDecimal("-2000.1")
   end
 
 
   it '"2 0o0.1" should be parsed as 2000.1 (with O instead of 0)' do
-    MoneyParser.parse("2 0o0.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2 0o0.1").should == BigDecimal("2000.1")
   end
 
 
   it '"$2 000.1" should be parsed as 2000.1 (with a dollar sign)' do
-    MoneyParser.parse("$2 000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("$2 000.1").should == BigDecimal("2000.1")
   end
 
 
   it '"€2 000.1" should be parsed as 2000.1 (with a euro sign)' do
-    MoneyParser.parse("€2 000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("€2 000.1").should == BigDecimal("2000.1")
   end
 
 
   it '"£2 000.1" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("£2 000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("£2 000.1").should == BigDecimal("2000.1")
   end
 
 
   it '"₤2 000.1" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("₤2 000.1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("₤2 000.1").should == BigDecimal("2000.1")
   end
 
 
   it '"2 000,1" should be parsed as 2000.1 ' do
-    MoneyParser.parse("2 000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2 000,1").should == BigDecimal("2000.1")
   end
 
 
   it '"-2 000,1" should be parsed as -2000.1 (negative amount)' do
-    MoneyParser.parse("-2 000,1").should == BigDecimal.new("-2000.1")
+    MoneyParser.parse("-2 000,1").should == BigDecimal("-2000.1")
   end
 
 
   it '"2 o00,1" should be parsed as 2000.1 (with O instead of 0)' do
-    MoneyParser.parse("2 o00,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2 o00,1").should == BigDecimal("2000.1")
   end
 
 
   it '"$2 000,1" should be parsed as 2000.1 (with a dollar sign)' do
-    MoneyParser.parse("$2 000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("$2 000,1").should == BigDecimal("2000.1")
   end
 
 
   it '"€2 000,1" should be parsed as 2000.1 (with a euro sign)' do
-    MoneyParser.parse("€2 000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("€2 000,1").should == BigDecimal("2000.1")
   end
 
 
   it '"£2 000,1" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("£2 000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("£2 000,1").should == BigDecimal("2000.1")
   end
 
 
   it '"₤2 000,1" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("₤2 000,1").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("₤2 000,1").should == BigDecimal("2000.1")
   end
 
 
   it '"1,222,000.1" should be parsed as 1222000.1 ' do
-    MoneyParser.parse("1,222,000.1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1,222,000.1").should == BigDecimal("1222000.1")
   end
 
 
   it '"-1,222,000.1" should be parsed as -1222000.1 (negative amount)' do
-    MoneyParser.parse("-1,222,000.1").should == BigDecimal.new("-1222000.1")
+    MoneyParser.parse("-1,222,000.1").should == BigDecimal("-1222000.1")
   end
 
 
   it '"1,222,0o0.1" should be parsed as 1222000.1 (with O instead of 0)' do
-    MoneyParser.parse("1,222,0o0.1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1,222,0o0.1").should == BigDecimal("1222000.1")
   end
 
 
   it '"$1,222,000.1" should be parsed as 1222000.1 (with a dollar sign)' do
-    MoneyParser.parse("$1,222,000.1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("$1,222,000.1").should == BigDecimal("1222000.1")
   end
 
 
   it '"€1,222,000.1" should be parsed as 1222000.1 (with a euro sign)' do
-    MoneyParser.parse("€1,222,000.1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("€1,222,000.1").should == BigDecimal("1222000.1")
   end
 
 
   it '"£1,222,000.1" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("£1,222,000.1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("£1,222,000.1").should == BigDecimal("1222000.1")
   end
 
 
   it '"₤1,222,000.1" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("₤1,222,000.1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("₤1,222,000.1").should == BigDecimal("1222000.1")
   end
 
 
   it '"1.222.000,1" should be parsed as 1222000.1 ' do
-    MoneyParser.parse("1.222.000,1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1.222.000,1").should == BigDecimal("1222000.1")
   end
 
 
   it '"- 1.222.000,1" should be parsed as -1222000.1 (negative amount)' do
-    MoneyParser.parse("- 1.222.000,1").should == BigDecimal.new("-1222000.1")
+    MoneyParser.parse("- 1.222.000,1").should == BigDecimal("-1222000.1")
   end
 
 
   it '"1.222.00o,1" should be parsed as 1222000.1 (with O instead of 0)' do
-    MoneyParser.parse("1.222.00o,1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1.222.00o,1").should == BigDecimal("1222000.1")
   end
 
 
   it '"$1.222.000,1" should be parsed as 1222000.1 (with a dollar sign)' do
-    MoneyParser.parse("$1.222.000,1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("$1.222.000,1").should == BigDecimal("1222000.1")
   end
 
 
   it '"€1.222.000,1" should be parsed as 1222000.1 (with a euro sign)' do
-    MoneyParser.parse("€1.222.000,1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("€1.222.000,1").should == BigDecimal("1222000.1")
   end
 
 
   it '"£1.222.000,1" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("£1.222.000,1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("£1.222.000,1").should == BigDecimal("1222000.1")
   end
 
 
   it '"₤1.222.000,1" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("₤1.222.000,1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("₤1.222.000,1").should == BigDecimal("1222000.1")
   end
 
 
   it '"1 222 000.1" should be parsed as 1222000.1 ' do
-    MoneyParser.parse("1 222 000.1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1 222 000.1").should == BigDecimal("1222000.1")
   end
 
 
   it '" - 1 222 000.1" should be parsed as -1222000.1 (negative amount)' do
-    MoneyParser.parse(" - 1 222 000.1").should == BigDecimal.new("-1222000.1")
+    MoneyParser.parse(" - 1 222 000.1").should == BigDecimal("-1222000.1")
   end
 
 
   it '"1 222 0o0.1" should be parsed as 1222000.1 (with O instead of 0)' do
-    MoneyParser.parse("1 222 0o0.1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1 222 0o0.1").should == BigDecimal("1222000.1")
   end
 
 
   it '"$1 222 000.1" should be parsed as 1222000.1 (with a dollar sign)' do
-    MoneyParser.parse("$1 222 000.1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("$1 222 000.1").should == BigDecimal("1222000.1")
   end
 
 
   it '"€1 222 000.1" should be parsed as 1222000.1 (with a euro sign)' do
-    MoneyParser.parse("€1 222 000.1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("€1 222 000.1").should == BigDecimal("1222000.1")
   end
 
 
   it '"£1 222 000.1" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("£1 222 000.1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("£1 222 000.1").should == BigDecimal("1222000.1")
   end
 
 
   it '"₤1 222 000.1" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("₤1 222 000.1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("₤1 222 000.1").should == BigDecimal("1222000.1")
   end
 
 
   it '"1 222 000,1" should be parsed as 1222000.1 ' do
-    MoneyParser.parse("1 222 000,1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1 222 000,1").should == BigDecimal("1222000.1")
   end
 
 
   it '" -1 222 000,1" should be parsed as -1222000.1 (negative amount)' do
-    MoneyParser.parse(" -1 222 000,1").should == BigDecimal.new("-1222000.1")
+    MoneyParser.parse(" -1 222 000,1").should == BigDecimal("-1222000.1")
   end
 
 
   it '"1 222 00o,1" should be parsed as 1222000.1 (with O instead of 0)' do
-    MoneyParser.parse("1 222 00o,1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1 222 00o,1").should == BigDecimal("1222000.1")
   end
 
 
   it '"$1 222 000,1" should be parsed as 1222000.1 (with a dollar sign)' do
-    MoneyParser.parse("$1 222 000,1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("$1 222 000,1").should == BigDecimal("1222000.1")
   end
 
 
   it '"€1 222 000,1" should be parsed as 1222000.1 (with a euro sign)' do
-    MoneyParser.parse("€1 222 000,1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("€1 222 000,1").should == BigDecimal("1222000.1")
   end
 
 
   it '"£1 222 000,1" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("£1 222 000,1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("£1 222 000,1").should == BigDecimal("1222000.1")
   end
 
 
   it '"₤1 222 000,1" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("₤1 222 000,1").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("₤1 222 000,1").should == BigDecimal("1222000.1")
   end
 
 
   it '"2,000.10" should be parsed as 2000.1 ' do
-    MoneyParser.parse("2,000.10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2,000.10").should == BigDecimal("2000.1")
   end
 
 
   it '" -2,000.10" should be parsed as -2000.1 (negative amount)' do
-    MoneyParser.parse(" -2,000.10").should == BigDecimal.new("-2000.1")
+    MoneyParser.parse(" -2,000.10").should == BigDecimal("-2000.1")
   end
 
 
   it '"2,0o0.10" should be parsed as 2000.1 (with O instead of 0)' do
-    MoneyParser.parse("2,0o0.10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2,0o0.10").should == BigDecimal("2000.1")
   end
 
 
   it '"$2,000.10" should be parsed as 2000.1 (with a dollar sign)' do
-    MoneyParser.parse("$2,000.10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("$2,000.10").should == BigDecimal("2000.1")
   end
 
 
   it '"€2,000.10" should be parsed as 2000.1 (with a euro sign)' do
-    MoneyParser.parse("€2,000.10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("€2,000.10").should == BigDecimal("2000.1")
   end
 
 
   it '"£2,000.10" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("£2,000.10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("£2,000.10").should == BigDecimal("2000.1")
   end
 
 
   it '"₤2,000.10" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("₤2,000.10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("₤2,000.10").should == BigDecimal("2000.1")
   end
 
 
   it '"2.000,10" should be parsed as 2000.1 ' do
-    MoneyParser.parse("2.000,10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2.000,10").should == BigDecimal("2000.1")
   end
 
 
   it '" - 2.000,10" should be parsed as -2000.1 (negative amount)' do
-    MoneyParser.parse(" - 2.000,10").should == BigDecimal.new("-2000.1")
+    MoneyParser.parse(" - 2.000,10").should == BigDecimal("-2000.1")
   end
 
 
   it '"2.00o,10" should be parsed as 2000.1 (with O instead of 0)' do
-    MoneyParser.parse("2.00o,10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2.00o,10").should == BigDecimal("2000.1")
   end
 
 
   it '"$2.000,10" should be parsed as 2000.1 (with a dollar sign)' do
-    MoneyParser.parse("$2.000,10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("$2.000,10").should == BigDecimal("2000.1")
   end
 
 
   it '"€2.000,10" should be parsed as 2000.1 (with a euro sign)' do
-    MoneyParser.parse("€2.000,10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("€2.000,10").should == BigDecimal("2000.1")
   end
 
 
   it '"£2.000,10" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("£2.000,10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("£2.000,10").should == BigDecimal("2000.1")
   end
 
 
   it '"₤2.000,10" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("₤2.000,10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("₤2.000,10").should == BigDecimal("2000.1")
   end
 
 
   it '"2 000.10" should be parsed as 2000.1 ' do
-    MoneyParser.parse("2 000.10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2 000.10").should == BigDecimal("2000.1")
   end
 
 
   it '" -2 000.10" should be parsed as -2000.1 (negative amount)' do
-    MoneyParser.parse(" -2 000.10").should == BigDecimal.new("-2000.1")
+    MoneyParser.parse(" -2 000.10").should == BigDecimal("-2000.1")
   end
 
 
   it '"2 o00.10" should be parsed as 2000.1 (with O instead of 0)' do
-    MoneyParser.parse("2 o00.10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2 o00.10").should == BigDecimal("2000.1")
   end
 
 
   it '"$2 000.10" should be parsed as 2000.1 (with a dollar sign)' do
-    MoneyParser.parse("$2 000.10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("$2 000.10").should == BigDecimal("2000.1")
   end
 
 
   it '"€2 000.10" should be parsed as 2000.1 (with a euro sign)' do
-    MoneyParser.parse("€2 000.10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("€2 000.10").should == BigDecimal("2000.1")
   end
 
 
   it '"£2 000.10" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("£2 000.10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("£2 000.10").should == BigDecimal("2000.1")
   end
 
 
   it '"₤2 000.10" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("₤2 000.10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("₤2 000.10").should == BigDecimal("2000.1")
   end
 
 
   it '"2 000,10" should be parsed as 2000.1 ' do
-    MoneyParser.parse("2 000,10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2 000,10").should == BigDecimal("2000.1")
   end
 
 
   it '" - 2 000,10" should be parsed as -2000.1 (negative amount)' do
-    MoneyParser.parse(" - 2 000,10").should == BigDecimal.new("-2000.1")
+    MoneyParser.parse(" - 2 000,10").should == BigDecimal("-2000.1")
   end
 
 
   it '"2 00o,10" should be parsed as 2000.1 (with O instead of 0)' do
-    MoneyParser.parse("2 00o,10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("2 00o,10").should == BigDecimal("2000.1")
   end
 
 
   it '"$2 000,10" should be parsed as 2000.1 (with a dollar sign)' do
-    MoneyParser.parse("$2 000,10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("$2 000,10").should == BigDecimal("2000.1")
   end
 
 
   it '"€2 000,10" should be parsed as 2000.1 (with a euro sign)' do
-    MoneyParser.parse("€2 000,10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("€2 000,10").should == BigDecimal("2000.1")
   end
 
 
   it '"£2 000,10" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("£2 000,10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("£2 000,10").should == BigDecimal("2000.1")
   end
 
 
   it '"₤2 000,10" should be parsed as 2000.1 (with a pound sign)' do
-    MoneyParser.parse("₤2 000,10").should == BigDecimal.new("2000.1")
+    MoneyParser.parse("₤2 000,10").should == BigDecimal("2000.1")
   end
 
 
   it '"1,222,000.10" should be parsed as 1222000.1 ' do
-    MoneyParser.parse("1,222,000.10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1,222,000.10").should == BigDecimal("1222000.1")
   end
 
 
   it '" -1,222,000.10" should be parsed as -1222000.1 (negative amount)' do
-    MoneyParser.parse(" -1,222,000.10").should == BigDecimal.new("-1222000.1")
+    MoneyParser.parse(" -1,222,000.10").should == BigDecimal("-1222000.1")
   end
 
 
   it '"1,222,00o.10" should be parsed as 1222000.1 (with O instead of 0)' do
-    MoneyParser.parse("1,222,00o.10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1,222,00o.10").should == BigDecimal("1222000.1")
   end
 
 
   it '"$1,222,000.10" should be parsed as 1222000.1 (with a dollar sign)' do
-    MoneyParser.parse("$1,222,000.10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("$1,222,000.10").should == BigDecimal("1222000.1")
   end
 
 
   it '"€1,222,000.10" should be parsed as 1222000.1 (with a euro sign)' do
-    MoneyParser.parse("€1,222,000.10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("€1,222,000.10").should == BigDecimal("1222000.1")
   end
 
 
   it '"£1,222,000.10" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("£1,222,000.10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("£1,222,000.10").should == BigDecimal("1222000.1")
   end
 
 
   it '"₤1,222,000.10" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("₤1,222,000.10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("₤1,222,000.10").should == BigDecimal("1222000.1")
   end
 
 
   it '"1.222.000,10" should be parsed as 1222000.1 ' do
-    MoneyParser.parse("1.222.000,10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1.222.000,10").should == BigDecimal("1222000.1")
   end
 
 
   it '" - 1.222.000,10" should be parsed as -1222000.1 (negative amount)' do
-    MoneyParser.parse(" - 1.222.000,10").should == BigDecimal.new("-1222000.1")
+    MoneyParser.parse(" - 1.222.000,10").should == BigDecimal("-1222000.1")
   end
 
 
   it '"1.222.o00,10" should be parsed as 1222000.1 (with O instead of 0)' do
-    MoneyParser.parse("1.222.o00,10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1.222.o00,10").should == BigDecimal("1222000.1")
   end
 
 
   it '"$1.222.000,10" should be parsed as 1222000.1 (with a dollar sign)' do
-    MoneyParser.parse("$1.222.000,10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("$1.222.000,10").should == BigDecimal("1222000.1")
   end
 
 
   it '"€1.222.000,10" should be parsed as 1222000.1 (with a euro sign)' do
-    MoneyParser.parse("€1.222.000,10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("€1.222.000,10").should == BigDecimal("1222000.1")
   end
 
 
   it '"£1.222.000,10" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("£1.222.000,10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("£1.222.000,10").should == BigDecimal("1222000.1")
   end
 
 
   it '"₤1.222.000,10" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("₤1.222.000,10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("₤1.222.000,10").should == BigDecimal("1222000.1")
   end
 
 
   it '"1 222 000.10" should be parsed as 1222000.1 ' do
-    MoneyParser.parse("1 222 000.10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1 222 000.10").should == BigDecimal("1222000.1")
   end
 
 
   it '"- 1 222 000.10" should be parsed as -1222000.1 (negative amount)' do
-    MoneyParser.parse("- 1 222 000.10").should == BigDecimal.new("-1222000.1")
+    MoneyParser.parse("- 1 222 000.10").should == BigDecimal("-1222000.1")
   end
 
 
   it '"1 222 o00.10" should be parsed as 1222000.1 (with O instead of 0)' do
-    MoneyParser.parse("1 222 o00.10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1 222 o00.10").should == BigDecimal("1222000.1")
   end
 
 
   it '"$1 222 000.10" should be parsed as 1222000.1 (with a dollar sign)' do
-    MoneyParser.parse("$1 222 000.10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("$1 222 000.10").should == BigDecimal("1222000.1")
   end
 
 
   it '"€1 222 000.10" should be parsed as 1222000.1 (with a euro sign)' do
-    MoneyParser.parse("€1 222 000.10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("€1 222 000.10").should == BigDecimal("1222000.1")
   end
 
 
   it '"£1 222 000.10" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("£1 222 000.10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("£1 222 000.10").should == BigDecimal("1222000.1")
   end
 
 
   it '"₤1 222 000.10" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("₤1 222 000.10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("₤1 222 000.10").should == BigDecimal("1222000.1")
   end
 
 
   it '"1 222 000,10" should be parsed as 1222000.1 ' do
-    MoneyParser.parse("1 222 000,10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1 222 000,10").should == BigDecimal("1222000.1")
   end
 
 
   it '"-1 222 000,10" should be parsed as -1222000.1 (negative amount)' do
-    MoneyParser.parse("-1 222 000,10").should == BigDecimal.new("-1222000.1")
+    MoneyParser.parse("-1 222 000,10").should == BigDecimal("-1222000.1")
   end
 
 
   it '"1 222 o00,10" should be parsed as 1222000.1 (with O instead of 0)' do
-    MoneyParser.parse("1 222 o00,10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("1 222 o00,10").should == BigDecimal("1222000.1")
   end
 
 
   it '"$1 222 000,10" should be parsed as 1222000.1 (with a dollar sign)' do
-    MoneyParser.parse("$1 222 000,10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("$1 222 000,10").should == BigDecimal("1222000.1")
   end
 
 
   it '"€1 222 000,10" should be parsed as 1222000.1 (with a euro sign)' do
-    MoneyParser.parse("€1 222 000,10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("€1 222 000,10").should == BigDecimal("1222000.1")
   end
 
 
   it '"£1 222 000,10" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("£1 222 000,10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("£1 222 000,10").should == BigDecimal("1222000.1")
   end
 
 
   it '"₤1 222 000,10" should be parsed as 1222000.1 (with a pound sign)' do
-    MoneyParser.parse("₤1 222 000,10").should == BigDecimal.new("1222000.1")
+    MoneyParser.parse("₤1 222 000,10").should == BigDecimal("1222000.1")
   end
 
 
   it '"1 222 000" should be parsed as 1222000.0 ' do
-    MoneyParser.parse("1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '" -1 222 000" should be parsed as -1222000.0 (negative amount)' do
-    MoneyParser.parse(" -1 222 000").should == BigDecimal.new("-1222000.0")
+    MoneyParser.parse(" -1 222 000").should == BigDecimal("-1222000.0")
   end
 
 
   it '"1 222 0o0" should be parsed as 1222000.0 (with O instead of 0)' do
-    MoneyParser.parse("1 222 0o0").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("1 222 0o0").should == BigDecimal("1222000.0")
   end
 
 
   it '"$1 222 000" should be parsed as 1222000.0 (with a dollar sign)' do
-    MoneyParser.parse("$1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("$1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"€1 222 000" should be parsed as 1222000.0 (with a euro sign)' do
-    MoneyParser.parse("€1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("€1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"£1 222 000" should be parsed as 1222000.0 (with a pound sign)' do
-    MoneyParser.parse("£1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("£1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"₤1 222 000" should be parsed as 1222000.0 (with a pound sign)' do
-    MoneyParser.parse("₤1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("₤1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"1 222 000" should be parsed as 1222000.0 ' do
-    MoneyParser.parse("1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '" -1 222 000" should be parsed as -1222000.0 (negative amount)' do
-    MoneyParser.parse(" -1 222 000").should == BigDecimal.new("-1222000.0")
+    MoneyParser.parse(" -1 222 000").should == BigDecimal("-1222000.0")
   end
 
 
   it '"1 222 o00" should be parsed as 1222000.0 (with O instead of 0)' do
-    MoneyParser.parse("1 222 o00").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("1 222 o00").should == BigDecimal("1222000.0")
   end
 
 
   it '"$1 222 000" should be parsed as 1222000.0 (with a dollar sign)' do
-    MoneyParser.parse("$1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("$1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"€1 222 000" should be parsed as 1222000.0 (with a euro sign)' do
-    MoneyParser.parse("€1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("€1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"£1 222 000" should be parsed as 1222000.0 (with a pound sign)' do
-    MoneyParser.parse("£1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("£1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"₤1 222 000" should be parsed as 1222000.0 (with a pound sign)' do
-    MoneyParser.parse("₤1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("₤1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"1,222,000" should be parsed as 1222000.0 ' do
-    MoneyParser.parse("1,222,000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("1,222,000").should == BigDecimal("1222000.0")
   end
 
 
   it '" -1,222,000" should be parsed as -1222000.0 (negative amount)' do
-    MoneyParser.parse(" -1,222,000").should == BigDecimal.new("-1222000.0")
+    MoneyParser.parse(" -1,222,000").should == BigDecimal("-1222000.0")
   end
 
 
   it '"1,222,o00" should be parsed as 1222000.0 (with O instead of 0)' do
-    MoneyParser.parse("1,222,o00").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("1,222,o00").should == BigDecimal("1222000.0")
   end
 
 
   it '"$1,222,000" should be parsed as 1222000.0 (with a dollar sign)' do
-    MoneyParser.parse("$1,222,000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("$1,222,000").should == BigDecimal("1222000.0")
   end
 
 
   it '"€1,222,000" should be parsed as 1222000.0 (with a euro sign)' do
-    MoneyParser.parse("€1,222,000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("€1,222,000").should == BigDecimal("1222000.0")
   end
 
 
   it '"£1,222,000" should be parsed as 1222000.0 (with a pound sign)' do
-    MoneyParser.parse("£1,222,000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("£1,222,000").should == BigDecimal("1222000.0")
   end
 
 
   it '"₤1,222,000" should be parsed as 1222000.0 (with a pound sign)' do
-    MoneyParser.parse("₤1,222,000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("₤1,222,000").should == BigDecimal("1222000.0")
   end
 
 
   it '"1.222.000" should be parsed as 1222000.0 ' do
-    MoneyParser.parse("1.222.000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("1.222.000").should == BigDecimal("1222000.0")
   end
 
 
   it '" -1.222.000" should be parsed as -1222000.0 (negative amount)' do
-    MoneyParser.parse(" -1.222.000").should == BigDecimal.new("-1222000.0")
+    MoneyParser.parse(" -1.222.000").should == BigDecimal("-1222000.0")
   end
 
 
   it '"1.222.00o" should be parsed as 1222000.0 (with O instead of 0)' do
-    MoneyParser.parse("1.222.00o").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("1.222.00o").should == BigDecimal("1222000.0")
   end
 
 
   it '"$1.222.000" should be parsed as 1222000.0 (with a dollar sign)' do
-    MoneyParser.parse("$1.222.000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("$1.222.000").should == BigDecimal("1222000.0")
   end
 
 
   it '"€1.222.000" should be parsed as 1222000.0 (with a euro sign)' do
-    MoneyParser.parse("€1.222.000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("€1.222.000").should == BigDecimal("1222000.0")
   end
 
 
   it '"£1.222.000" should be parsed as 1222000.0 (with a pound sign)' do
-    MoneyParser.parse("£1.222.000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("£1.222.000").should == BigDecimal("1222000.0")
   end
 
 
   it '"₤1.222.000" should be parsed as 1222000.0 (with a pound sign)' do
-    MoneyParser.parse("₤1.222.000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("₤1.222.000").should == BigDecimal("1222000.0")
   end
 
 
   it '"1 222 000" should be parsed as 1222000.0 ' do
-    MoneyParser.parse("1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"- 1 222 000" should be parsed as -1222000.0 (negative amount)' do
-    MoneyParser.parse("- 1 222 000").should == BigDecimal.new("-1222000.0")
+    MoneyParser.parse("- 1 222 000").should == BigDecimal("-1222000.0")
   end
 
 
   it '"1 222 0o0" should be parsed as 1222000.0 (with O instead of 0)' do
-    MoneyParser.parse("1 222 0o0").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("1 222 0o0").should == BigDecimal("1222000.0")
   end
 
 
   it '"$1 222 000" should be parsed as 1222000.0 (with a dollar sign)' do
-    MoneyParser.parse("$1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("$1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"€1 222 000" should be parsed as 1222000.0 (with a euro sign)' do
-    MoneyParser.parse("€1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("€1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"£1 222 000" should be parsed as 1222000.0 (with a pound sign)' do
-    MoneyParser.parse("£1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("£1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"₤1 222 000" should be parsed as 1222000.0 (with a pound sign)' do
-    MoneyParser.parse("₤1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("₤1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"1 222 000" should be parsed as 1222000.0 ' do
-    MoneyParser.parse("1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '" - 1 222 000" should be parsed as -1222000.0 (negative amount)' do
-    MoneyParser.parse(" - 1 222 000").should == BigDecimal.new("-1222000.0")
+    MoneyParser.parse(" - 1 222 000").should == BigDecimal("-1222000.0")
   end
 
 
   it '"1 222 00o" should be parsed as 1222000.0 (with O instead of 0)' do
-    MoneyParser.parse("1 222 00o").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("1 222 00o").should == BigDecimal("1222000.0")
   end
 
 
   it '"$1 222 000" should be parsed as 1222000.0 (with a dollar sign)' do
-    MoneyParser.parse("$1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("$1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"€1 222 000" should be parsed as 1222000.0 (with a euro sign)' do
-    MoneyParser.parse("€1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("€1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"£1 222 000" should be parsed as 1222000.0 (with a pound sign)' do
-    MoneyParser.parse("£1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("£1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"₤1 222 000" should be parsed as 1222000.0 (with a pound sign)' do
-    MoneyParser.parse("₤1 222 000").should == BigDecimal.new("1222000.0")
+    MoneyParser.parse("₤1 222 000").should == BigDecimal("1222000.0")
   end
 
 
   it '"2,123" should be parsed as 2123.0 ' do
-    MoneyParser.parse("2,123").should == BigDecimal.new("2123.0")
+    MoneyParser.parse("2,123").should == BigDecimal("2123.0")
   end
 
 
   it '" - 2,123" should be parsed as -2123.0 (negative amount)' do
-    MoneyParser.parse(" - 2,123").should == BigDecimal.new("-2123.0")
+    MoneyParser.parse(" - 2,123").should == BigDecimal("-2123.0")
   end
 
 
   it '"$2,123" should be parsed as 2123.0 (with a dollar sign)' do
-    MoneyParser.parse("$2,123").should == BigDecimal.new("2123.0")
+    MoneyParser.parse("$2,123").should == BigDecimal("2123.0")
   end
 
 
   it '"€2,123" should be parsed as 2123.0 (with a euro sign)' do
-    MoneyParser.parse("€2,123").should == BigDecimal.new("2123.0")
+    MoneyParser.parse("€2,123").should == BigDecimal("2123.0")
   end
 
 
   it '"£2,123" should be parsed as 2123.0 (with a pound sign)' do
-    MoneyParser.parse("£2,123").should == BigDecimal.new("2123.0")
+    MoneyParser.parse("£2,123").should == BigDecimal("2123.0")
   end
 
 
   it '"₤2,123" should be parsed as 2123.0 (with a pound sign)' do
-    MoneyParser.parse("₤2,123").should == BigDecimal.new("2123.0")
+    MoneyParser.parse("₤2,123").should == BigDecimal("2123.0")
   end
 
 
   it '"2.123" should be parsed as 2123.0 ' do
-    MoneyParser.parse("2.123").should == BigDecimal.new("2123.0")
+    MoneyParser.parse("2.123").should == BigDecimal("2123.0")
   end
 
 
   it '" - 2.123" should be parsed as -2123.0 (negative amount)' do
-    MoneyParser.parse(" - 2.123").should == BigDecimal.new("-2123.0")
+    MoneyParser.parse(" - 2.123").should == BigDecimal("-2123.0")
   end
 
 
   it '"$2.123" should be parsed as 2123.0 (with a dollar sign)' do
-    MoneyParser.parse("$2.123").should == BigDecimal.new("2123.0")
+    MoneyParser.parse("$2.123").should == BigDecimal("2123.0")
   end
 
 
   it '"€2.123" should be parsed as 2123.0 (with a euro sign)' do
-    MoneyParser.parse("€2.123").should == BigDecimal.new("2123.0")
+    MoneyParser.parse("€2.123").should == BigDecimal("2123.0")
   end
 
 
   it '"£2.123" should be parsed as 2123.0 (with a pound sign)' do
-    MoneyParser.parse("£2.123").should == BigDecimal.new("2123.0")
+    MoneyParser.parse("£2.123").should == BigDecimal("2123.0")
   end
 
 
   it '"₤2.123" should be parsed as 2123.0 (with a pound sign)' do
-    MoneyParser.parse("₤2.123").should == BigDecimal.new("2123.0")
+    MoneyParser.parse("₤2.123").should == BigDecimal("2123.0")
   end
 
 
   it '"2,12" should be parsed as 2.12 ' do
-    MoneyParser.parse("2,12").should == BigDecimal.new("2.12")
+    MoneyParser.parse("2,12").should == BigDecimal("2.12")
   end
 
 
   it '"- 2,12" should be parsed as -2.12 (negative amount)' do
-    MoneyParser.parse("- 2,12").should == BigDecimal.new("-2.12")
+    MoneyParser.parse("- 2,12").should == BigDecimal("-2.12")
   end
 
 
   it '"$2,12" should be parsed as 2.12 (with a dollar sign)' do
-    MoneyParser.parse("$2,12").should == BigDecimal.new("2.12")
+    MoneyParser.parse("$2,12").should == BigDecimal("2.12")
   end
 
 
   it '"€2,12" should be parsed as 2.12 (with a euro sign)' do
-    MoneyParser.parse("€2,12").should == BigDecimal.new("2.12")
+    MoneyParser.parse("€2,12").should == BigDecimal("2.12")
   end
 
 
   it '"£2,12" should be parsed as 2.12 (with a pound sign)' do
-    MoneyParser.parse("£2,12").should == BigDecimal.new("2.12")
+    MoneyParser.parse("£2,12").should == BigDecimal("2.12")
   end
 
 
   it '"₤2,12" should be parsed as 2.12 (with a pound sign)' do
-    MoneyParser.parse("₤2,12").should == BigDecimal.new("2.12")
+    MoneyParser.parse("₤2,12").should == BigDecimal("2.12")
   end
 
 
@@ -1718,32 +1718,32 @@ describe MoneyParser do
 
 
   it '"1" should be parsed as 1.0 ' do
-    MoneyParser.parse("1").should == BigDecimal.new("1.0")
+    MoneyParser.parse("1").should == BigDecimal("1.0")
   end
 
 
   it '"-1" should be parsed as -1.0 (negative amount)' do
-    MoneyParser.parse("-1").should == BigDecimal.new("-1.0")
+    MoneyParser.parse("-1").should == BigDecimal("-1.0")
   end
 
 
   it '"$1" should be parsed as 1.0 (with a dollar sign)' do
-    MoneyParser.parse("$1").should == BigDecimal.new("1.0")
+    MoneyParser.parse("$1").should == BigDecimal("1.0")
   end
 
 
   it '"€1" should be parsed as 1.0 (with a euro sign)' do
-    MoneyParser.parse("€1").should == BigDecimal.new("1.0")
+    MoneyParser.parse("€1").should == BigDecimal("1.0")
   end
 
 
   it '"£1" should be parsed as 1.0 (with a pound sign)' do
-    MoneyParser.parse("£1").should == BigDecimal.new("1.0")
+    MoneyParser.parse("£1").should == BigDecimal("1.0")
   end
 
 
   it '"₤1" should be parsed as 1.0 (with a pound sign)' do
-    MoneyParser.parse("₤1").should == BigDecimal.new("1.0")
+    MoneyParser.parse("₤1").should == BigDecimal("1.0")
   end
 
 


### PR DESCRIPTION
> warning: BigDecimal.new is deprecated; use BigDecimal() method instead.